### PR TITLE
ローカル変数の初期化で構造体のパディングや共用体の残りの要素が0にならないのを修正

### DIFF
--- a/src/gifcc.h
+++ b/src/gifcc.h
@@ -290,6 +290,7 @@ typedef enum {
 typedef enum {
   ST_EXPR,
   ST_COMPOUND,
+  ST_DECL,
   ST_IF,
   ST_SWITCH,
   ST_CASE,
@@ -431,7 +432,10 @@ typedef struct Expr {
     const StringLiteral *str;
 
     // EX_COMPOUND
-    Initializer *compound;
+    struct {
+      StackVar *stack_var;
+      Initializer *init;
+    } compound;
 
     // EX_CALL
     struct {
@@ -501,6 +505,11 @@ typedef struct Expr {
   };
 } Expr;
 
+typedef struct {
+  StackVar *stack_var;
+  Initializer *init;
+} StackVarDecl;
+
 typedef struct Stmt {
   stmt_t ty;
   Type *val_type;
@@ -518,7 +527,7 @@ typedef struct Stmt {
   // ST_DEFAULT:  default: <body>
   // ST_LABEL:    <label>: <body>
   char *label;
-  struct Expr *init;
+  struct Stmt *init;
   struct Expr *cond;
   struct Expr *inc;
   struct Stmt *then_stmt;
@@ -534,7 +543,11 @@ typedef struct Stmt {
   // ST_RETURN: return <expr>:
   struct Expr *expr;
 
-  Vector *stmts; // tyがST_COMPOUNDの場合のみ使う
+  // ST_COMPOUND
+  Vector *stmts;
+
+  // ST_DECL
+  Vector *decl;
 } Stmt;
 
 typedef struct Member {

--- a/src/sema.c
+++ b/src/sema.c
@@ -619,7 +619,7 @@ static void walk_expr(Expr *expr) {
   case EX_STR:
     return;
   case EX_COMPOUND:
-    walk_initializer(expr->compound);
+    walk_initializer(expr->compound.init);
     return;
   case EX_STMT:
     walk_stmt(expr->stmt);
@@ -830,6 +830,12 @@ static void walk_stmt(Stmt *stmt) {
       walk_stmt(vec_get(stmt->stmts, i));
     }
     return;
+  case ST_DECL:
+    for (int i = 0; i < vec_len(stmt->decl); i++) {
+      StackVarDecl *decl = vec_get(stmt->decl, i);
+      walk_initializer(decl->init);
+    }
+    return;
   case ST_IF:
     walk_expr(stmt->cond);
     walk_stmt(stmt->then_stmt);
@@ -864,7 +870,7 @@ static void walk_stmt(Stmt *stmt) {
     return;
   case ST_FOR:
     if (stmt->init != NULL) {
-      walk_expr(stmt->init);
+      walk_stmt(stmt->init);
     }
     if (stmt->cond != NULL) {
       walk_expr(stmt->cond);

--- a/test/all.c
+++ b/test/all.c
@@ -2643,6 +2643,18 @@ static void test84(void) {
   !cond ? abort() : TEST_PRINTF("OK");
 }
 
+static void test85(void) {
+  typedef union {
+    char x;
+    int a[16];
+  } U;
+
+  U u = {0};
+  for (int i = 0; i < 16; i++) {
+    CHECK_INT(0, u.a[i]);
+  }
+}
+
 int main(int argc, char *argv[]) {
   Test test_list[] = {
       TEST(test01), TEST(test02), TEST(test03), TEST(test04), TEST(test05),
@@ -2661,7 +2673,8 @@ int main(int argc, char *argv[]) {
       TEST(test66), TEST(test67), TEST(test68), TEST(test69), TEST(test70),
       TEST(test71), TEST(test72), TEST(test73), TEST(test74), TEST(test75),
       TEST(test76), TEST(test77), TEST(test78), TEST(test79), TEST(test80),
-      TEST(test81), TEST(test82), TEST(test83), TEST(test84), {NULL, NULL},
+      TEST(test81), TEST(test82), TEST(test83), TEST(test84), TEST(test85),
+      {NULL, NULL},
   };
   RUN_TEST(argc, argv, test_list);
 }


### PR DESCRIPTION
codegen で Initializer を直接扱うよう変更した