### PR TITLE
構造体メンバーアクセスのコード生成を改善

### DIFF
--- a/src/gifcc.h
+++ b/src/gifcc.h
@@ -451,13 +451,13 @@ typedef struct Expr {
     // EX_DOT
     struct {
       Expr *operand;
-      Member *member;
+      Vector *members;
     } dot;
 
     // EX_ARROW
     struct {
       Expr *operand;
-      Member *member;
+      Vector *members;
     } arrow;
 
     // EX_COND
@@ -805,6 +805,15 @@ void gen(FILE *fp, TranslationUnit *tunit);
 // inline functions
 static inline char *get_label(Function *func, char *name) {
   return map_get(func->label_map, name);
+}
+
+static inline int get_members_offset(Vector *members) {
+  int offset = 0;
+  for (int i = 0; i < vec_len(members); i++) {
+    Member *member = vec_get(members, i);
+    offset += member->offset;
+  }
+  return offset;
 }
 
 #endif // GIFCC_H

--- a/src/main.c
+++ b/src/main.c
@@ -196,16 +196,36 @@ static void dump_expr(FILE *fp, Expr *expr, int level) {
   case EX_POST_DEC:
     dump_unop_expr(fp, expr, "POST_DEC", level);
     return;
-  case EX_DOT:
-    dump_expr_start(fp, expr, level, "DOT %s", expr->dot.member->name);
+  case EX_DOT: {
+    String *s = new_string();
+    for (int i = 0; i < vec_len(expr->dot.members); i++) {
+      Member *m = vec_get(expr->dot.members, i);
+      if (i > 0) {
+        str_push(s, '.');
+      }
+      str_append(s, m->name);
+    }
+    str_push(s, '\0');
+    dump_expr_start(fp, expr, level, "DOT %s", str_get_raw(s));
     dump_expr(fp, expr->dot.operand, level + 1);
     dump_expr_end(fp, expr, level);
     return;
-  case EX_ARROW:
-    dump_expr_start(fp, expr, level, "ARROW %s", expr->arrow.member->name);
+  }
+  case EX_ARROW: {
+    String *s = new_string();
+    for (int i = 0; i < vec_len(expr->arrow.members); i++) {
+      Member *m = vec_get(expr->arrow.members, i);
+      if (i > 0) {
+        str_push(s, '.');
+      }
+      str_append(s, m->name);
+    }
+    str_push(s, '\0');
+    dump_expr_start(fp, expr, level, "ARROW %s", str_get_raw(s));
     dump_expr(fp, expr->arrow.operand, level + 1);
     dump_expr_end(fp, expr, level);
     return;
+  }
 
   // binary operator
   case EX_ADD:

--- a/src/parse.c
+++ b/src/parse.c
@@ -2022,7 +2022,8 @@ static Expr *new_expr_dot(Scope *scope, Expr *operand, const char *name,
 
   Expr *expr = new_expr(EX_DOT, member->type, range);
   expr->dot.operand = operand;
-  expr->dot.member = member;
+  expr->dot.members = new_vector();
+  vec_push(expr->dot.members, member);
   return expr;
 }
 
@@ -2047,7 +2048,8 @@ static Expr *new_expr_arrow(Scope *scope, Expr *operand, const char *name,
 
   Expr *expr = new_expr(EX_ARROW, member->type, range);
   expr->arrow.operand = operand;
-  expr->arrow.member = member;
+  expr->arrow.members = new_vector();
+  vec_push(expr->arrow.members, member);
   return expr;
 }
 

--- a/test/all.c
+++ b/test/all.c
@@ -2549,17 +2549,19 @@ static void test77(void) {
 }
 
 typedef struct Test78_S {
-  int a;
-  int b;
-  int c;
+  struct {
+    int a;
+    int b;
+    int c;
+  } x;
 } Test78_S;
 
 static Test78_S test78_f(void) { return (Test78_S){1, 2, 3}; }
 
 static void test78(void) {
-  CHECK_INT(6, test78_f().a + test78_f().b + test78_f().c);
+  CHECK_INT(6, test78_f().x.a + test78_f().x.b + test78_f().x.c);
   Test78_S s = test78_f();
-  CHECK_INT(6, s.a + s.b + s.c);
+  CHECK_INT(6, s.x.a + s.x.b + s.x.c);
 }
 
 static void test79(void) {


### PR DESCRIPTION
`->` や `.` が連続する場合のコード生成を改善